### PR TITLE
Dublin-core title element + styling

### DIFF
--- a/opencontext_py/apps/indexer/solrdocument.py
+++ b/opencontext_py/apps/indexer/solrdocument.py
@@ -251,7 +251,10 @@ class SolrDocument:
         #default, adds to interest score once other fields determined
         self.fields['interest_score'] = 0
         self.fields['item_type'] = self.oc_item.item_type
-        self.fields['text'] += self.oc_item.json_ld['label'] + ' \n'
+        if 'dc-terms:title' in self.oc_item.json_ld:
+            self.fields['text'] += self.oc_item.json_ld['dc-terms:title'] + ' \n'
+        else:
+            self.fields['text'] += self.oc_item.json_ld['label'] + ' \n'
 
     def make_slug_type_uri_label(self):
         """ makes a slug_type_uri_label field for solr """

--- a/opencontext_py/apps/ocitems/ocitem/templating.py
+++ b/opencontext_py/apps/ocitems/ocitem/templating.py
@@ -768,15 +768,10 @@ class Citation():
                 self.cite_authors = ', '.join(self.item_authors)
             else:
                 self.cite_authors = 'Open Context Editors'
-            parent_prefix = False
-            if self.context is not False:
-                parent_items = self.context.parent_labels
-                if len(parent_items) > 1:
-                    # del parent_items[0]
-                    parent_prefix = ' / '.join(parent_items)
-            self.cite_title = json_ld['label']
-            if parent_prefix is not False:
-                self.cite_title += ' from ' + parent_prefix
+            if 'dc-terms:title' in json_ld:
+                self.cite_title = json_ld['dc-terms:title']
+            else:
+                self.cite_title = json_ld['label']
             self.cite_year += published.strftime('%Y')
             self.cite_released = published.strftime('%Y-%m-%d')
             self.uri = json_ld['id']

--- a/opencontext_py/templates/items/citation.html
+++ b/opencontext_py/templates/items/citation.html
@@ -3,8 +3,8 @@
         <div class="panel-heading">
             <h3 class="panel-title">Suggested Citation:</h3>
         </div>
-        <div class="panel-body" id="ciation">
-            {{ item.citation.cite_authors }}. "{{ item.citation.cite_title }}". ({{ item.citation.cite_year }})
+        <div class="panel-body" id="citation">
+            {{ item.citation.cite_authors }}. "<span id="item-title">{{ item.citation.cite_title }}</span>". ({{ item.citation.cite_year }})
             {% if item.citation.project.label != False %}
                 In <em>{{ item.citation.project.label  }}</em>. 
             {%endif%}
@@ -17,5 +17,9 @@
                 ARK: {{ item.citation.ark }}
             {%endif%}
         </div>
+        <script type="text/javascript">
+            var cite_title = document.getElementById("item-title");
+            cite_title.innerHTML = cite_title.innerHTML.split('/').join( '<span class="title_sep">/</span>');
+        </script>
     </div>
 {% endblock %}

--- a/static/oc/css/general.css
+++ b/static/oc/css/general.css
@@ -131,6 +131,14 @@ div.subjects-links-cell {
 	text-align: left;
 }
 /* So long uri in Citation has good wrapping */
+#item-title {
+	max-width:200px;
+    word-wrap:break-word;
+}
+span.title_sep {
+	padding-left: 3px;
+	padding-right: 3px;
+}
 #item-uri {
 	max-width:200px;
     word-wrap:break-word;


### PR DESCRIPTION
Useful for citation and indexing. We're now including the dc-terms:title
in the document indexing (for full-text search).