### PR TITLE
Update requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -21,5 +21,6 @@ python-dateutil==2.2
 feedparser==5.1.3
 lxml==3.4.4
 jsonfield==1.0.3
-django-revision==1.9.3
+django-reversion==1.9.3
+django-revision==0.1.6
 pillow==2.9.0


### PR DESCRIPTION
latest django-revision version is 0.1.6 [https://pypi.python.org/pypi/django-revision/0.1.6]
latest django-reversion version is 1.9.3 [https://pypi.python.org/pypi/django-reversion/1.9.3]

```
pip install django-revision==1.9.3Collecting django-revision==1.9.3
  Could not find a version that satisfies the requirement django-revision==1.9.3 (from versions: 0.1.2, 0.1.3, 0.1.4, 0.1.5, 0.1.6a0, 0.1.6a1, 0.1.6)
No matching distribution found for django-revision==1.9.3
```