### PR TITLE
Update requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ Unidecode==0.04.16
 anyjson==0.3.3
 coverage==3.7.1
 coveralls==0.4.2
-django-debug-toolbar==1.4.1
+django-debug-toolbar==1.4
 docopt==0.6.1
 geojson==1.0.7
 mysolr==0.8.3


### PR DESCRIPTION
latest django-debug-toolbar is 1.4 [https://pypi.python.org/pypi/django-debug-toolbar]?

"Collecting django-debug-toolbar==1.4.1
Could not find a version that satisfies the requirement django-debug-toolbar==1.4.1 (from versions: 0.7.0, 0.8.0, 0.8.1, 0.8.2, 0.8.3, 0.8.4, 0.8.5, 0.9.1, 0.9.2, 0.9.3, 0.9.4, 0.10.0, 0.10.1, 0.10.2, 0.11, 0.11.0, 1.0, 1.0.1, 1.1, 1.2, 1.2.1, 1.2.2, 1.3.0, 1.3.2, 1.4)
No matching distribution found for django-debug-toolbar==1.4.1"