### PR TITLE
Media indexing: related subjects properties

### DIFF
--- a/opencontext_py/apps/indexer/crawler.py
+++ b/opencontext_py/apps/indexer/crawler.py
@@ -59,7 +59,9 @@ class Crawler():
             # Process the UUID list in chunks
             for uuid in islice(self.uuidlist, 0, chunksize):
                 try:
-                    solrdocument = SolrDocument(uuid).fields
+                    sd_obj = SolrDocument(uuid)
+                    sd_obj.process_item()
+                    solrdocument = sd_obj.fields 
                     if crawlutil().is_valid_document(solrdocument):
                         try:
                             manifest = Manifest.objects.get(uuid=uuid)
@@ -119,7 +121,9 @@ class Crawler():
                     manifest = False
                 if manifest is not False:
                     try:
-                        solrdocument = SolrDocument(uuid).fields
+                        sd_obj = SolrDocument(uuid)
+                        sd_obj.process_item()
+                        solrdocument = sd_obj.fields
                         if crawlutil().is_valid_document(solrdocument):
                             if solrdocument is not None:
                                 i += 1
@@ -183,7 +187,9 @@ class Crawler():
         print('\nAttempting to index document ' + uuid + '...\n')
         start_time = time.time()
         try:
-            solrdocument = SolrDocument(uuid).fields
+            sd_obj = SolrDocument(uuid)
+            sd_obj.process_item()
+            solrdocument = sd_obj.fields
             if crawlutil().is_valid_document(solrdocument):
                 # Commit the document and save the response status.
                 # Note: solr.update() expects a list

--- a/opencontext_py/apps/indexer/reindex.py
+++ b/opencontext_py/apps/indexer/reindex.py
@@ -14,10 +14,16 @@ class SolrReIndex():
     """ This class contains methods to make updates to
         the solr index especially after edits
 
+from opencontext_py.apps.ocitems.manifest.models import Manifest
 from opencontext_py.apps.indexer.reindex import SolrReIndex
+uuids = []
+media_items = Manifest.objects.filter(item_type='media').exclude(indexed__gt='2016-04-12')
+for item in media_items:
+    uuids.append(item.uuid)
+    
+print('Items to index: ' + str(len(uuids)))
 sri = SolrReIndex()
-sri.annotated_after = '2015-10-26'
-sri.reindex()
+sri.reindex_uuids(uuids)
 
     """
 

--- a/opencontext_py/apps/searcher/search/views.py
+++ b/opencontext_py/apps/searcher/search/views.py
@@ -366,6 +366,9 @@ def media_html_view(request, spatial_context=None):
         solr_s = SolrSearch()
         solr_s.mem_cache_obj = mem_cache_obj
         solr_s.item_type_limit = 'media'
+        # add category facet fields for related items
+        solr_s.facet_fields += SolrSearch.REL_CAT_FACET_FIELDS
+        solr_s.stats_fields += SolrSearch.MEDIA_STATS_FIELDS
         if solr_s.solr is not False:
             response = solr_s.search_solr(request_dict_json)
             mem_cache_obj = solr_s.mem_cache_obj  # reused cached memory items
@@ -433,6 +436,9 @@ def media_json_view(request, spatial_context=None):
         solr_s = SolrSearch()
         solr_s.mem_cache_obj = mem_cache_obj
         solr_s.item_type_limit = 'media'
+        # add category facet fields for related items
+        solr_s.facet_fields += SolrSearch.REL_CAT_FACET_FIELDS
+        solr_s.stats_fields += SolrSearch.MEDIA_STATS_FIELDS
         if solr_s.solr is not False:
             response = solr_s.search_solr(request_dict_json)
             mem_cache_obj = solr_s.mem_cache_obj  # reused cached memory items

--- a/opencontext_py/apps/searcher/solrsearcher/filters.py
+++ b/opencontext_py/apps/searcher/solrsearcher/filters.py
@@ -252,6 +252,7 @@ class ActiveFilters():
             with a label and set of entities (in cases of OR
             searchs)
         """
+        related_suffix = ''
         output = {'label': False,
                   'data-type': 'id',
                   'slug': False,
@@ -262,9 +263,12 @@ class ActiveFilters():
         else:
             vals = [act_val]
         for val in vals:
-            f_entity = self.mem_cache_obj.get_entity(val, False)
+            qm = QueryMaker()
+            db_val = qm.clean_related_slug(val)
+            if val != db_val:
+                related_suffix = ' (for related items)'
+            f_entity = self.mem_cache_obj.get_entity(db_val, False)
             if f_entity is not False:
-                qm = QueryMaker()
                 # get the solr field data type
                 ent_solr_data_type = qm.get_solr_field_type(f_entity.data_type)
                 if ent_solr_data_type is not False \
@@ -274,6 +278,6 @@ class ActiveFilters():
                 output['entities'].append(f_entity)
             else:
                 labels.append(val)
-        output['label'] = ' OR '.join(labels)
+        output['label'] = (' OR '.join(labels)) + related_suffix
         output['slug'] = '-or-'.join(vals)
         return output

--- a/opencontext_py/apps/searcher/solrsearcher/models.py
+++ b/opencontext_py/apps/searcher/solrsearcher/models.py
@@ -41,6 +41,10 @@ class SolrSearch():
                        'oc_gen_media___pred_id',
                        'oc_gen_persons___pred_id']
 
+    REL_CAT_FACET_FIELDS = ['rel__oc_gen_subjects___pred_id']
+    GENERAL_STATS_FIELDS = ['updated', 'published']
+    MEDIA_STATS_FIELDS = ['filesize___pred_numeric']
+
     def __init__(self):
         self.solr = False
         self.solr_connect()
@@ -49,6 +53,7 @@ class SolrSearch():
         self.mem_cache_obj = MemoryCache()  # memory caching object
         self.entities = {}  # entities involved in a search request
         self.facet_fields = self.DEFAULT_FACET_FIELDS
+        self.stats_fields = self.GENERAL_STATS_FIELDS
         self.rows = 20
         self.start = 0
         self.max_rows = 10000
@@ -112,7 +117,7 @@ class SolrSearch():
         query['facet.field'] = []
         query['facet.range'] = []
         query['stats'] = 'true'
-        query['stats.field'] = ['updated', 'published']
+        query['stats.field'] = self.stats_fields
         query['sort'] = SortingOptions.DEFAULT_SOLR_SORT
         s_param = self.get_request_param(request_dict,
                                          'sort',


### PR DESCRIPTION
Add to indexing of media items by getting properties from related media
resources. Enables search based on properties that describe subjects
associated to media resources. This all about denormalizing the solr
index even more.