### PR TITLE
Better metadata management of export tables

### DIFF
--- a/opencontext_py/apps/exports/exptables/models.py
+++ b/opencontext_py/apps/exports/exptables/models.py
@@ -15,7 +15,8 @@ class ExpTable(models.Model):
     field_count = models.IntegerField()
     row_count = models.IntegerField()
     meta_json = JSONField(default={},
-                          load_kwargs={'object_pairs_hook': collections.OrderedDict})
+                          load_kwargs={'object_pairs_hook': collections.OrderedDict},
+                          blank=True)
     short_des = models.CharField(max_length=200)
     abstract = models.TextField()
     created = models.DateTimeField()

--- a/opencontext_py/apps/ldata/linkannotations/models.py
+++ b/opencontext_py/apps/ldata/linkannotations/models.py
@@ -1,5 +1,7 @@
 import reversion  # version control object
 import hashlib
+import collections
+from jsonfield import JSONField  # json field for complex objects
 from django.db import models
 from opencontext_py.apps.ldata.linkentities.models import LinkEntityGeneration
 
@@ -34,6 +36,9 @@ class LinkAnnotation(models.Model):
     source_id = models.CharField(max_length=200)  # longer than the normal 50 for URI-identifed vocabs
     predicate_uri = models.CharField(max_length=200, db_index=True)
     object_uri = models.CharField(max_length=200, db_index=True)
+    obj_extra = JSONField(default={},
+                          load_kwargs={'object_pairs_hook': collections.OrderedDict},
+                          blank=True)
     creator_uuid = models.CharField(max_length=50)
     updated = models.DateTimeField(auto_now=True)
 


### PR DESCRIPTION
Since we need to be able to edit export table metadata, it makes sense
to use more general Open Context modes / code, rather than reinvent the
wheel. However, export table metadata needs to be somewhat different, in
that it needs to record counts of object items. Therefore, this change
includes an extension to the link_annoations model so that we can add
extra information to the assertion. That extra information is in the
form of a JSON encoded dict object.

There's a method that we will include temporarily to migrate the
existing table metadata to the link_annotations table.