### PR TITLE
Redirect for first version of OC

### DIFF
--- a/opencontext_py/apps/ocitems/subjects/views.py
+++ b/opencontext_py/apps/ocitems/subjects/views.py
@@ -23,6 +23,19 @@ def index(request):
     return redirect(new_url, permanent=True)
 
 
+def old_redirect_view(request):
+    """ Redirects from the original PHP version of
+        Open Context when ".php" was in URLs
+    """
+    rp = RootPath()
+    base_url = rp.get_baseurl()
+    new_url = base_url + '/subjects-search/'
+    if 'item' in request.GET:
+        uuid = request.GET['item']
+        new_url = base_url + '/subjects/' + uuid
+    return redirect(new_url, permanent=True)
+
+
 def html_view(request, uuid):
     ocitem = OCitem()
     ocitem.get_item(uuid)

--- a/opencontext_py/urls.py
+++ b/opencontext_py/urls.py
@@ -79,6 +79,7 @@ urlpatterns = patterns('',
                        url(r'^search/(?P<spatial_context>\S+)?.json', SearchViews.json_view, name='search_json'),
                        url(r'^search/(?P<spatial_context>\S+)?', SearchViews.html_view, name='search_html'),
                        # Subjects views for main records (subjects of observations)
+                       url(r'^database/space.php', SubjectViews.old_redirect_view, name='old_redirect_html'),
                        url(r'^subjects/(?P<uuid>\S+).json', SubjectViews.json_view, name='subjects_json'),
                        url(r'^subjects/(?P<uuid>\S+)', SubjectViews.html_view, name='subjects_html'),
                        url(r'^subjects', SubjectViews.index, name='subjects_index_html_s'),


### PR DESCRIPTION
The first version of OC had badly designed URLs with ".php" in them.
This redirects links to the better designed current version