### PR TITLE
Fixed content negotiation caching problem

### DIFF
--- a/opencontext_py/apps/ocitems/documents/views.py
+++ b/opencontext_py/apps/ocitems/documents/views.py
@@ -6,6 +6,7 @@ from opencontext_py.libs.requestnegotiation import RequestNegotiation
 from opencontext_py.apps.ocitems.ocitem.models import OCitem
 from opencontext_py.apps.ocitems.ocitem.templating import TemplateItem
 from django.template import RequestContext, loader
+from django.utils.cache import patch_vary_headers
 
 
 # A document item is a text document (usually HTML/XHTML)
@@ -46,15 +47,19 @@ def html_view(request, uuid):
                 if 'json' in req_neg.use_response_type:
                     # content negotiation requested JSON or JSON-LD
                     request.content_type = req_neg.use_response_type
-                    return HttpResponse(json.dumps(ocitem.json_ld,
-                                        ensure_ascii=False, indent=4),
-                                        content_type=req_neg.use_response_type + "; charset=utf8")
+                    response = HttpResponse(json.dumps(ocitem.json_ld,
+                                            ensure_ascii=False, indent=4),
+                                            content_type=req_neg.use_response_type + "; charset=utf8")
+                    patch_vary_headers(response, ['accept', 'Accept', 'content-type'])
+                    return response
                 else:
                     context = RequestContext(request,
                                              {'item': temp_item,
                                               'base_url': base_url,
                                               'user': request.user})
-                    return HttpResponse(template.render(context))
+                    response = HttpResponse(template.render(context))
+                    patch_vary_headers(response, ['accept', 'Accept', 'content-type'])
+                    return response
             else:
                 # client wanted a mimetype we don't support
                 return HttpResponse(req_neg.error_message,

--- a/opencontext_py/apps/ocitems/mediafiles/views.py
+++ b/opencontext_py/apps/ocitems/mediafiles/views.py
@@ -7,6 +7,7 @@ from opencontext_py.libs.requestnegotiation import RequestNegotiation
 from opencontext_py.apps.ocitems.ocitem.models import OCitem
 from opencontext_py.apps.ocitems.ocitem.templating import TemplateItem
 from django.template import RequestContext, loader
+from django.utils.cache import patch_vary_headers
 
 
 # A media resource describes metadata about a binary file (usually an image)
@@ -45,16 +46,20 @@ def html_view(request, uuid):
                 if 'json' in req_neg.use_response_type:
                     # content negotiation requested JSON or JSON-LD
                     request.content_type = req_neg.use_response_type
-                    return HttpResponse(json.dumps(ocitem.json_ld,
-                                        ensure_ascii=False, indent=4),
-                                        content_type=req_neg.use_response_type + "; charset=utf8")
+                    response = HttpResponse(json.dumps(ocitem.json_ld,
+                                            ensure_ascii=False, indent=4),
+                                            content_type=req_neg.use_response_type + "; charset=utf8")
+                    patch_vary_headers(response, ['accept', 'Accept', 'content-type'])
+                    return response
                 else:
                     context = RequestContext(request,
                                              {'item': temp_item,
                                               'fullview': False,
                                               'base_url': base_url,
                                               'user': request.user})
-                    return HttpResponse(template.render(context))
+                    response = HttpResponse(template.render(context))
+                    patch_vary_headers(response, ['accept', 'Accept', 'content-type'])
+                    return response
             else:
                 # client wanted a mimetype we don't support
                 return HttpResponse(req_neg.error_message,

--- a/opencontext_py/apps/ocitems/octypes/views.py
+++ b/opencontext_py/apps/ocitems/octypes/views.py
@@ -6,6 +6,7 @@ from opencontext_py.apps.ocitems.octypes.supplement import TypeSupplement
 from opencontext_py.apps.ocitems.ocitem.models import OCitem
 from opencontext_py.apps.ocitems.ocitem.templating import TemplateItem
 from django.template import RequestContext, loader
+from django.utils.cache import patch_vary_headers
 
 
 # An octype item is a concept from a controlled vocabulary that originates from
@@ -43,14 +44,18 @@ def html_view(request, uuid):
                 if 'json' in req_neg.use_response_type:
                     # content negotiation requested JSON or JSON-LD
                     request.content_type = req_neg.use_response_type
-                    return HttpResponse(json.dumps(ocitem.json_ld,
-                                        ensure_ascii=False, indent=4),
-                                        content_type=req_neg.use_response_type + "; charset=utf8")
+                    response = HttpResponse(json.dumps(ocitem.json_ld,
+                                            ensure_ascii=False, indent=4),
+                                            content_type=req_neg.use_response_type + "; charset=utf8")
+                    patch_vary_headers(response, ['accept', 'Accept', 'content-type'])
+                    return response
                 else:
                     context = RequestContext(request,
                                              {'item': temp_item,
                                               'base_url': base_url})
-                    return HttpResponse(template.render(context))
+                    response = HttpResponse(template.render(context))
+                    patch_vary_headers(response, ['accept', 'Accept', 'content-type'])
+                    return response
             else:
                 # client wanted a mimetype we don't support
                 return HttpResponse(req_neg.error_message,

--- a/opencontext_py/apps/ocitems/subjects/views.py
+++ b/opencontext_py/apps/ocitems/subjects/views.py
@@ -7,6 +7,7 @@ from opencontext_py.apps.ocitems.ocitem.models import OCitem
 from opencontext_py.apps.ocitems.ocitem.templating import TemplateItem
 from opencontext_py.apps.ocitems.subjects.supplement import SubjectSupplement
 from django.template import RequestContext, loader
+from django.utils.cache import patch_vary_headers
 
 
 # A subject is a generic item that is the subbject of observations
@@ -62,15 +63,19 @@ def html_view(request, uuid):
                 if 'json' in req_neg.use_response_type:
                     # content negotiation requested JSON or JSON-LD
                     request.content_type = req_neg.use_response_type
-                    return HttpResponse(json.dumps(ocitem.json_ld,
-                                        ensure_ascii=False, indent=4),
-                                        content_type=req_neg.use_response_type + "; charset=utf8")
+                    response = HttpResponse(json.dumps(ocitem.json_ld,
+                                            ensure_ascii=False, indent=4),
+                                            content_type=req_neg.use_response_type + "; charset=utf8")
+                    patch_vary_headers(response, ['accept', 'Accept', 'content-type'])
+                    return response
                 else:
                     context = RequestContext(request,
                                              {'item': temp_item,
                                               'base_url': base_url,
                                               'user': request.user})
-                    return HttpResponse(template.render(context))
+                    response = HttpResponse(template.render(context))
+                    patch_vary_headers(response, ['accept', 'Accept', 'content-type'])
+                    return response
             else:
                 # client wanted a mimetype we don't support
                 return HttpResponse(req_neg.error_message,

--- a/opencontext_py/libs/requestnegotiation.py
+++ b/opencontext_py/libs/requestnegotiation.py
@@ -23,7 +23,8 @@ class RequestNegotiation():
         if '*/*' in client_accepts:
             # client happy to accept all
             self.use_response_type = self.default_type
-        elif 'text/*' in client_accepts \
+        elif ('text/*' in client_accepts \
+             or 'text/plain' in client_accepts) \
              and 'text/' in self.default_type:
             self.use_response_type = self.default_type
         elif self.default_type in client_accepts:


### PR DESCRIPTION
The "patch_vary_headers" makes sure that we keep different versions of
cached responses, depending on the "accept" header of the client. This
prevents HTML returned when a client wanted JSON.