### PR TITLE
Fix link to Blog (Heritage Bytes)

### DIFF
--- a/opencontext_py/templates/about/people.html
+++ b/opencontext_py/templates/about/people.html
@@ -95,7 +95,7 @@
 							<span typeof="foaf:Person" resource="http://alexandriaarchive.org/about/people/">Eric Kansa</span>
 						</h3>
 						<p>I'm the Program Director for Open Context. I have a Ph.D. in Anthropology, and archeological field experience in the Near East, Egypt, Italy and North America. My research interests explore research data informatics, research data policy, ethics, and professional context of the digital humanities.</p>
-						<p>I run research and development for Open Context and manage the technical aspects of data publishing and archiving, including systems interoperability, data integration, and indexing. I blog at <a href="http://ux.opencontext.org/blog/">Heritage Bytes</a>, and am on Twitter <a href="https://twitter.com/ekansa">@ekansa</a>. (<a href="mailto:ekansa@alexandriaarchive.org">Contact me!</a>)
+						<p>I run research and development for Open Context and manage the technical aspects of data publishing and archiving, including systems interoperability, data integration, and indexing. I blog at <a href="http://ux.opencontext.org/">Heritage Bytes</a>, and am on Twitter <a href="https://twitter.com/ekansa">@ekansa</a>. (<a href="mailto:ekansa@alexandriaarchive.org">Contact me!</a>)
 						</p>
 					</div>
 				</div>


### PR DESCRIPTION
Old link points to "http://ux.opencontext.org/blog" (404)