### PR TITLE
Estimation form fix

### DIFF
--- a/opencontext_py/apps/about/views.py
+++ b/opencontext_py/apps/about/views.py
@@ -206,6 +206,14 @@ def process_estimate(request):
                                  ensure_ascii=False)
         return HttpResponse(json_output,
                             content_type='application/json; charset=utf8')
+    elif request.method == 'GET':
+        cost = CostEstimator()
+        output = cost.process_estimate(request.GET)
+        json_output = json.dumps(output,
+                                 indent=4,
+                                 ensure_ascii=False)
+        return HttpResponse(json_output,
+                            content_type='application/json; charset=utf8')
     else:
         return HttpResponseForbidden
 

--- a/static/oc/js/about/estimation.js
+++ b/static/oc/js/about/estimation.js
@@ -16,7 +16,7 @@ function estimation(){
 		var data = this.make_estimate_data();
 		var url = this.make_url('/about/process-estimate');
 		return $.ajax({
-				type: "POST",
+				type: "GET",
 				url: url,
 				dataType: "json",
 				context: this,


### PR DESCRIPTION
Hard to replicate permisions error with the estimation form. Use GET
instead of POST method to avoid, which is reasonable given that we're
just getting data not actually storing any (so OK for REST principles).