### PR TITLE
Update sqlparse from 0.1.19 to 0.2.4

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -58,7 +58,7 @@ Shapely==1.5.15
 
 six==1.10.0
 
-sqlparse==0.1.19
+sqlparse==0.2.4
 
 titlecase==0.9.0
 


### PR DESCRIPTION
because 0.1.19 breaks django-debug-toolbar as detailed in https://github.com/jazzband/django-debug-toolbar/issues/862