### PR TITLE
Updated sub-project solr document creation

### DIFF
--- a/opencontext_py/tests/regression/indexer/test_solrddocument.py
+++ b/opencontext_py/tests/regression/indexer/test_solrddocument.py
@@ -148,6 +148,8 @@ def test_projects_is_sub_project():
     assert sd_obj.fields['uuid'] == uuid
     assert sd_obj.fields['item_type'] == 'projects'
     assert '52-digital-index-of-north-american-archaeology-dinaa' in sd_obj.fields['root___project_id_fq']
+    assert '52-digital-index-of-north-american-archaeology-dinaa' in sd_obj.fields['obj_all___project_id_fq']
+    assert '52-digital-index-of-north-american-archaeology-linking-si' in sd_obj.fields['obj_all___project_id_fq']
     assert not 'obj_all___context_id_fq' in sd_obj.fields
 
 


### PR DESCRIPTION
Updates to make sure sub-projects are get indexed properly in their parent projects.

The regression check for a few important attribute and values in the resulting solr documents that conform to our solr schema.  To run the regression tests:

`pytest opencontext_py/tests/regression/ -v`

Please note that the random tests iterate through all the projects to randomly select examples of all item_types and class_uris from the oc_manifest table. It can require about 45 minutes to fully run these tests as currently configured.
